### PR TITLE
Use working dir for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
 
 ## Outputs
 
-The action saves JSON results to `/github/workspace/testssl_results_<timestamp>.json`.
+The action saves JSON results to `testssl_results_<timestamp>.json`.
 
 ## About testssl.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,12 +6,9 @@ if [ -z "$INPUT_URI" ]; then
   exit 1
 fi
 
-# Set the output directory to /github/workspace
-OUTPUT_DIR="/github/workspace"
-
 # Generate a filename based on the INPUT_URI and timestamp
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-OUTPUT_FILE="$OUTPUT_DIR/testssl_results_${TIMESTAMP}.json"
+OUTPUT_FILE="testssl_results_${TIMESTAMP}.json"
 
 echo "Testing SSL/TLS for: $INPUT_URI"
 echo "Output will be saved to: $OUTPUT_FILE"


### PR DESCRIPTION
Simplify permissions and file management by using working dir for output